### PR TITLE
added missing headers

### DIFF
--- a/lib/sepa.js
+++ b/lib/sepa.js
@@ -17,6 +17,7 @@
 (function(exports) {
   var XSI_NAMESPACE = "http://www.w3.org/2001/XMLSchema-instance";
   var XSI_SCHEMALOC = "urn:iso:std:iso:20022:tech:xsd:pain.008.003.02 pain.008.003.02.xsd";
+  var XSI_NS        = "urn:iso:std:iso:20022:tech:xsd:pain.008.003.02";
 
   // TODO keep this configurable
   var ID_SEPARATOR = "."
@@ -71,7 +72,9 @@
       var doc = createDocument(docNS, "Document");
       var body = doc.documentElement;
 
-      body.setAttributeNS(XSI_NAMESPACE, "schemaLocation", XSI_SCHEMALOC);
+      body.setAttributeNS(XSI_NAMESPACE, "xmlns", XSI_NS);
+      body.setAttributeNS(XSI_NAMESPACE, "xmlns:xsi", XSI_NAMESPACE);
+      body.setAttributeNS(XSI_NAMESPACE, "xsi:schemaLocation", XSI_SCHEMALOC);
       var directDebit = doc.createElementNS(docNS, "CstmrDrctDbtInitn");
 
       directDebit.appendChild(this.grpHdr.toXML(doc));


### PR DESCRIPTION
Berliner Sparkasse won't accept the generated XML without
the xmlns / xmlns:xsi and xsi:schemaLocation.

This patch adds the two additional headers and prefixes
schemaLocation with xsi:
