### PR TITLE
fixed localInstrumentation

### DIFF
--- a/lib/sepa.js
+++ b/lib/sepa.js
@@ -396,9 +396,9 @@
 
       var pmtTpInf = n(pmtInf, 'PmtTpInf');
       r(pmtTpInf, 'SvcLvl', 'Cd', 'SEPA');
-      r(pmtTpInf, 'LclInstrm', 'Cd', this.localInstrumentation);
 
       if (this.method === PaymentInfoTypes.DirectDebit) {
+        r(pmtTpInf, 'LclInstrm', 'Cd', this.localInstrumentation);
         r(pmtTpInf, 'SeqTp', this.sequenceType);
         r(pmtInf, 'ReqdColltnDt', this.collectionDate.toISOString().substr(0, 10));
       }


### PR DESCRIPTION
line `r(pmtTpInf, 'LclInstrm', 'Cd', this.localInstrumentation);` should only be created on DirectDebit. Changing this line will make the xml file work on SEPA Transfers.