### PR TITLE
use transaction id, if end2endId is not provided

### DIFF
--- a/lib/sepa.js
+++ b/lib/sepa.js
@@ -547,7 +547,7 @@
 
       var paymentId = n(txInf, 'PmtId');
       r(paymentId, 'InstrId', this.id);
-      r(paymentId, 'EndToEndId', this.end2endId);
+      r(paymentId, 'EndToEndId', this.end2endId || this.id);
 
       if (this._type === TransactionTypes.DirectDebit) {
         r(txInf, 'InstdAmt', this.amount.toFixed(2)).setAttribute('Ccy', this.currency);


### PR DESCRIPTION
If end2end id is not provided the resulting XML looks like
```xml
<PmtId>
  <InstrId>WLD.20190531.0.1</InstrId>
  <EndToEndId/>
</PmtId>
```

since end2endId is a required field. Putting the transaction id in the would be great.  It would also have the appropriate uniqueness