### PR TITLE
only assert mandateSignatureDate for DirectDebit

### DIFF
--- a/lib/sepa.js
+++ b/lib/sepa.js
@@ -517,7 +517,10 @@
       assert(this.amount == this.amount.toFixed(2), 'amount has too many fractional digits');
       assert_length(this.purposeCode, 1, 4, 'purposeCode');
       assert_sepa_id_set2(this.mandateId, 'mandateId');
-      assert_date(this.mandateSignatureDate, 'mandateSignatureDate');
+      
+      if (this._type === TransactionTypes.DirectDebit) {
+        assert_date(this.mandateSignatureDate, 'mandateSignatureDate');
+      }
 
       assert_length(this[pullFrom + 'Name'], null, 70, pullFrom + 'Name');
       assert_length(this[pullFrom + 'Street'], null, 70, pullFrom + 'Street');


### PR DESCRIPTION
Mandate signatures are only required on transactions of type DirectDebit

