### PR TITLE
Added support for structured remittance info

### DIFF
--- a/lib/sepa.js
+++ b/lib/sepa.js
@@ -501,6 +501,14 @@
     /** Unstructured Remittance Info */
     remittanceInfo: '',
 
+    /** Structured Remittance Info */
+    structuredRemittanceInfo: {
+      typeCode: '',
+      issuer: '',
+      reference: ''
+    },
+  
+
     /** Name, Address, IBAN and BIC of the creditor */
     creditorName: '',
     creditorStreet: null,
@@ -529,6 +537,14 @@
       assert(countryMatches, 'country mismatch in BIC/IBAN');
 
       assert_length(this.remittanceInfo, null, 140, 'remittanceInfo');
+
+      // validate structured remittance information
+      if (this.structuredRemittanceInfo.reference) {
+        assert_length(this.structuredRemittanceInfo.typeCode, null, 35, 'typeCode');
+        assert_length(this.structuredRemittanceInfo.issuer, null, 35, 'issuer');
+        assert_length(this.structuredRemittanceInfo.reference, null, 35, 'reference');
+      }
+
     },
 
     toXML: function(doc) {
@@ -585,7 +601,18 @@
 
       r(txInf, recieverNodeName + 'Acct', 'Id', 'IBAN', this[pullFrom + 'IBAN']);
 
-      r(txInf, 'RmtInf', 'Ustrd', this.remittanceInfo);
+      var remittance = n(txInf, 'RmtInf');
+      if (this.structuredRemittanceInfo.reference) {
+        var structured = n(remittance, 'Strd');
+        var creditorRefInf = n(structured, 'CdtrRefInf');
+        var cdOrPrtry = n(creditorRefInf, 'Tp', 'CdOrPrtry');
+        r(cdOrPrtry, 'Cd', this.structuredRemittanceInfo.typeCode);
+        r(creditorRefInf, 'Issr', this.structuredRemittanceInfo.issuer);
+        r(creditorRefInf, 'Ref', this.structuredRemittanceInfo.reference);
+      } else {
+        r(remittance, 'Ustrd', this.remittanceInfo);
+      }
+
       o(txInf, 'Purp', 'Cd', this.purposeCode);
 
       return txInf;


### PR DESCRIPTION
I just added the support for structured remittance info.
If the "structuredRemittanceInfo.reference" has a value, then it overwrites the remittanceInfo string that was defined.