### PR TITLE
No longer set deprecated xmlVersion and xmlEncoding fields

### DIFF
--- a/lib/sepa.js
+++ b/lib/sepa.js
@@ -132,8 +132,6 @@
 
       var docNS = XSI_NS + this._painFormat;
       var doc = createDocument(docNS, 'Document');
-      doc.xmlVersion = this._xmlVersion;
-      doc.xmlEncoding = this._xmlEncoding;
       var body = doc.documentElement;
 
       body.setAttribute('xmlns:xsi', XSI_NAMESPACE);


### PR DESCRIPTION
See https://github.com/kewisch/sepa.js/issues/56.