### PR TITLE
fix: Check for valid SEPA characters

### DIFF
--- a/lib/sepa.js
+++ b/lib/sepa.js
@@ -29,8 +29,19 @@
   }
 
   var VALIDATIONS_ENABLED = true;
-  function enableValidations(enabled) {
+  var CHARSET_VALIDATION_ENABLED = true;
+  /**
+   * Controls the validation that is conducted when SepaDocuments are serialized.
+   *
+   * @param {boolean} enabled - Whether the validation should be conducted
+   * @param {boolean} [charsetValidationsEnabled=true] - If validation is enabled, whether fields
+   *    should be checked for the limited SEPA character set. You want to set this to false, e.g.,
+   *    if you are using this library to handle communication within Greece or Finnland, where
+   *    more characters are allowed.
+   */
+  function enableValidations(enabled, charsetValidationsEnabled = true) {
     VALIDATIONS_ENABLED = !!enabled;
+    CHARSET_VALIDATION_ENABLED = !!charsetValidationsEnabled;
   }
 
   var SEPATypes = {
@@ -511,7 +522,6 @@
       issuer: '',
       reference: ''
     },
-  
 
     /** Name, Address, IBAN and BIC of the creditor */
     creditorName: '',
@@ -524,11 +534,12 @@
     validate: function() {
       var pullFrom = this._type === TransactionTypes.Transfer ? 'creditor' : 'debtor';
 
-      assert_sepa_id_set1(this.end2endId, 'end2endId');
+      assert_valid_sepa_id(this.end2endId, 35, 'end2endId', CHARSET_VALIDATION_ENABLED);
       assert_range(this.amount, 0.01, 999999999.99, 'amount');
       assert(this.amount == this.amount.toFixed(2), 'amount has too many fractional digits');
       assert_length(this.purposeCode, 1, 4, 'purposeCode');
-      assert_sepa_id_set2(this.mandateId, 'mandateId');
+      assert_valid_sepa_id(this.mandateId, 35, 'mandateId', CHARSET_VALIDATION_ENABLED);
+
       assert_date(this.mandateSignatureDate, 'mandateSignatureDate');
 
       assert_length(this[pullFrom + 'Name'], null, 70, pullFrom + 'Name');
@@ -791,17 +802,29 @@
     }
   }
 
-  /** assert that the str uses characters from the first sepa id charset */
-  function assert_sepa_id_set1(str, member) {
-    if (str && !str.match(/([A-Za-z0-9]|[+|?|/|\-|:|(|)|.|,|'| ]){1,35}/)) {
-      throw new Error(member + ' doesn\'t match sepa id charset type 1 (found: ' + '"' + str + '")');
-    }
-  }
+  /**
+   * Checks whether the given string is a valid SEPA id.
+   *
+   * @param {string} str - The id to check
+   * @param {number} maxLength - The maximum length of the id
+   * @param {string} member - The name of the field that is validated
+   * @param {boolean} validateCharset - If the character set should be validated
+   */
+  function assert_valid_sepa_id(str, maxLength, member, validateCharset) {
+    assert_length(str, null, maxLength, member);
 
-  /** assert that the str uses characters from the second sepa id charset */
-  function assert_sepa_id_set2(str, member) {
-    if (str && !str.match(/([A-Za-z0-9]|[+|?|/|\-|:|(|)|.|,|']){1,35}/)) {
-      throw new Error(member + ' doesn\'t match sepa id charset type 2 (found: ' + '"' + str + '")');
+    if (validateCharset) {
+      if (str && !str.match(/([A-Za-z0-9]|[+|?|/|\-|:|(|)|.|,|' ]){1,35}/)) {
+        throw new Error(`${member} contains characters which are not in the SEPA character set (found: "${str}")`);
+      }
+    }
+
+    if (str && str.length > 1 && str.charAt(0) === '/') {
+      throw new Error(`${member} is an id and hence must not start with a "/". (found "${str}"`);
+    }
+
+    if (str && str.match(/\/\//)) {
+      throw new Error(`${member} is an id and hence must not contain "//". (found "${str}"`);
     }
   }
 

--- a/lib/sepa.test.js
+++ b/lib/sepa.test.js
@@ -61,6 +61,17 @@ describe('xml generation for transfer documents', () => {
     return doc;
   }
 
+  /** Adds a transaction to the first SepaPaymentInfo of the given SepaDocument */
+  function addTransaction(doc, endToEndId) {
+    const transaction = doc._paymentInfo[0].createTransaction();
+    transaction.creditorName = 'creditor-name';
+    transaction.creditorIBAN = A_VALID_IBAN;
+    transaction.amount = 1.0;
+    transaction.mandateSignatureDate = new Date();
+    transaction.end2endId = endToEndId;
+    doc._paymentInfo[0].addTransaction(transaction);
+  }
+
   test('debtor id is optional for transfer documents', () => {
     // GIVEN
     const doc = validTransferDocument({debtorId: null});
@@ -111,6 +122,95 @@ describe('xml generation for transfer documents', () => {
     const debtorId = select('/p:Document/p:CstmrCdtTrfInitn/p:PmtInf/p:Dbtr/p:Id', dom, true);
     expect(debtorId).not.toBeUndefined();
     expect(debtorId.textContent).toBe(validDutchCreditorId);
+  });
+
+  test('detects invalid characters for end2endId', () => {
+    // GIVEN
+    const doc = validTransferDocument({});
+    addTransaction(doc, 'Ö');
+
+    // WHEN THEN
+    expect(() => doc.toXML()).toThrow(Error);
+  });
+
+  test('accepts valid end2endId', () => {
+    // GIVEN
+    const doc = validTransferDocument({});
+    addTransaction(doc, 'ascii only end-2-end-id');
+
+    // WHEN
+    const xml = doc.toXML();
+
+    // THEN
+    expect(xml).not.toBeUndefined();
+  });
+
+  test('accepts all valid punctuation signs for end2endId', () => {
+    // GIVEN
+    const doc = validTransferDocument({});
+    addTransaction(doc, '-');
+    addTransaction(doc, '?');
+    addTransaction(doc, ':');
+    addTransaction(doc, '(');
+    addTransaction(doc, ')');
+    addTransaction(doc, '.');
+    addTransaction(doc, ',');
+    addTransaction(doc, '\'');
+    addTransaction(doc, '+');
+
+    // WHEN
+    const xml = doc.toXML();
+
+    // THEN
+    expect(xml).not.toBeUndefined();
+  });
+
+  test('Disabling charset validation works', () => {
+    try {
+      // GIVEN
+      const doc = validTransferDocument({});
+      const greekText = 'Κείμενο με ελληνικά γράμματα';
+      addTransaction(doc, greekText);
+      SEPA.enableValidations(true, false);
+
+      // WHEN
+      const xml  = doc.toXML();
+
+      // THEN
+      expect(xml).not.toBeUndefined();
+    } finally {
+      SEPA.enableValidations(true, true);
+    }
+  });
+
+  test('Rejects identifiers which are too long', () => {
+    // GIVEN
+    const doc = validTransferDocument({});
+    const longIdentifier = 'one-more-than-thirty-five-characters';
+    addTransaction(doc, {endToEndId: longIdentifier});
+
+    // WHEN THEN
+    expect(() => doc.toXML()).toThrow(Error);
+  });
+
+  test('Rejects ids which start with a /', () => {
+    // GIVEN
+    const doc = validTransferDocument({});
+    const invalidIdentifier = '/id-starts-with-slash';
+    addTransaction(doc, {endToEndId: invalidIdentifier});
+
+    // WHEN THEN
+    expect(()=>doc.toXML()).toThrow(Error);
+  });
+
+  test('Rejects ids which contain "//"', () => {
+    // GIVEN
+    const doc = validTransferDocument({});
+    const invalidIdentifier = 'an/id/with//double/slash';
+    addTransaction(doc, {endToEndId: invalidIdentifier});
+
+    // WHEN THEN
+    expect(()=>doc.toXML()).toThrow(Error);
   });
 });
 


### PR DESCRIPTION
Before, all characters were allowed in ids.

Also, allow to disable the validation in case documents need to be generated in the context of a SEPA AOS

Fixes kewisch#28