### PR TITLE
feat: Add support for originalCreditorId

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ info.creditorIBAN = "DE87123456781234567890";
 info.creditorBIC = "XMPLDEM0XXX";
 info.creditorName = "Example LLC";
 info.creditorId = "DE98ZZZ09999999999";
+info.originalCreditorId = "DE98ZZZ09999999998"; //optional
 info.batchBooking = true; //optional
 doc.addPaymentInfo(info);
 

--- a/examples/example.js
+++ b/examples/example.js
@@ -16,6 +16,7 @@ info.creditorIBAN = 'DE87123456781234567890';
 info.creditorBIC = 'XMPLDEM0XXX';
 info.creditorName = 'Example LLC';
 info.creditorId = 'DE98ZZZ09999999999';
+info.originalCreditorId = 'DE98ZZZ09999999998';
 doc.addPaymentInfo(info);
 
 var tx = info.createTransaction();

--- a/lib/sepa.js
+++ b/lib/sepa.js
@@ -287,6 +287,9 @@
     /** Id assigned to the creditor */
     creditorId: '',
 
+    /** Original Id assigned to the creditor */
+    originalCreditorId: '',
+
     /** Name, Address, IBAN and BIC of the creditor */
     creditorName: '',
     creditorStreet: null,
@@ -446,6 +449,12 @@
         var creditorScheme = n(pmtInf, 'CdtrSchmeId', 'Id', 'PrvtId', 'Othr');
         r(creditorScheme, 'Id', this.creditorId);
         r(creditorScheme, 'SchmeNm', 'Prtry', 'SEPA');
+      }
+
+      if (this.originalCreditorId) {
+        var originalCreditorScheme = n(pmtInf, 'OrgnlCdtrSchmeId', 'Id', 'PrvtId', 'Othr');
+        r(originalCreditorScheme, 'Id', this.originalCreditorId);
+        r(originalCreditorScheme, 'SchmeNm', 'Prtry', 'SEPA');
       }
 
       for (var i = 0, l = this._payments.length; i < l; ++i) {

--- a/lib/sepa.test.js
+++ b/lib/sepa.test.js
@@ -298,6 +298,24 @@ describe('xml generation for direct debit documents', () => {
     expect(creditorId).toBeUndefined();
   });
 
+  test('includes original creditor id when set', () => {
+    // GIVEN
+    const doc = validDirectDebitDocument({creditorId: 'IT66ZZZA1B2C3D4E5F6G7H8'});
+    doc._paymentInfo[0].originalCreditorId = 'DE98ZZZ09999999999';
+
+    // WHEN
+    const dom = doc.toXML();
+
+    // THEN
+    const select = xpath.useNamespaces({
+      p: `urn:iso:std:iso:20022:tech:xsd:${PAIN_FOR_DIRECT_DEBIT}`,
+    });
+
+    const originalCreditorId = select('/p:Document/p:CstmrDrctDbtInitn/p:PmtInf/p:OrgnlCdtrSchmeId/p:Id/p:PrvtId/p:Othr/p:Id', dom, true);
+    expect(originalCreditorId).not.toBeUndefined();
+    expect(originalCreditorId.textContent).toBe('DE98ZZZ09999999999');
+  });
+
   test('serialized document starts with proper xml declaration', () => {
     // GIVEN
     const doc = validDirectDebitDocument({});

--- a/types/sepa.d.ts
+++ b/types/sepa.d.ts
@@ -168,6 +168,8 @@ declare module "sepa" {
 
     /** Id assigned to the creditor */
     creditorId: string;
+    /** Original Id assigned to the creditor */
+    originalCreditorId: string;
     /** Name of the creditor */
     creditorName: string;
     /** Street of the creditor */


### PR DESCRIPTION
This adds support for specifying an original creditor ID, which is useful in scenarios such as creditor ID migrations or changes, and for processing return transactions (R-transactions).

A new optional property `originalCreditorId` has been added to the `SepaPaymentInfo` class. When this property is set, it will be included in the generated SEPA XML file as the `<OrgnlCdtrSchmeId>` element.

This resolves issue #177.