### PR TITLE
Add structured ISO 20022 postal address support (EPC/Swift November 2026 requirement)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,41 @@ info.addTransaction(tx);
 console.log(doc.toString());
 ```
 
+## Postal Addresses
+
+Payment info blocks and transactions expose the structured ISO 20022 postal
+address elements for their parties (`creditor*` / `debtor*`), emitted in the
+schema sequence order:
+
+| Field                          | ISO element     |
+| ------------------------------ | --------------- |
+| `creditorStreetName`           | `<StrtNm>`      |
+| `creditorBuildingNumber`       | `<BldgNb>`      |
+| `creditorPostCode`             | `<PstCd>`       |
+| `creditorTownName`             | `<TwnNm>`       |
+| `creditorCountrySubDivision`   | `<CtrySubDvsn>` |
+| `creditorCountry`              | `<Ctry>`        |
+| `creditorAddressLines`         | `<AdrLine>` (up to 7 entries) |
+
+```javascript
+// Fully structured address
+tx.creditorStreetName = "Rue de la Paix";
+tx.creditorBuildingNumber = "42";
+tx.creditorPostCode = "75002";
+tx.creditorTownName = "Paris";
+tx.creditorCountry = "FR";
+
+// Hybrid address: structured locality, street part kept unstructured
+tx.creditorPostCode = "75002";
+tx.creditorTownName = "Paris";
+tx.creditorCountry = "FR";
+tx.creditorAddressLines = ["123 Rue de la Paix", "Batiment B"];
+```
+
+The legacy `creditorStreet`/`creditorCity` (and `debtorStreet`/`debtorCity`)
+fields are deprecated. Their output is preserved for backward compatibility,
+and the structured fields take precedence when both are set.
+
 ### XML Result
 
 ```xml

--- a/lib/schema.test.js
+++ b/lib/schema.test.js
@@ -215,3 +215,120 @@ describe('direct debit with amendments validation tests',
       expect(validation).toBe(true);
     });
   });
+
+describe('structured postal address schema validation tests',
+  () => {
+    function setStructuredAddress(party, prefix) {
+      party[prefix + 'StreetName'] = 'Musterstrasse';
+      party[prefix + 'BuildingNumber'] = '17';
+      party[prefix + 'PostCode'] = '80331';
+      party[prefix + 'TownName'] = 'Munich';
+      party[prefix + 'Country'] = 'DE';
+    }
+
+    function setHybridAddress(party, prefix) {
+      party[prefix + 'PostCode'] = '75002';
+      party[prefix + 'TownName'] = 'Paris';
+      party[prefix + 'Country'] = 'FR';
+      party[prefix + 'AddressLines'] = ['123 Rue de la Paix', 'Batiment B'];
+    }
+
+    test.each([
+      'pain.001.001.02',
+      'pain.001.001.03',
+      'pain.001.001.08',
+      'pain.001.001.09',
+    ])('%p schema matches with structured and hybrid addresses', (format) => {
+      var doc = new SEPA.Document(format);
+      doc.grpHdr.id = 'XMPL.20140201.TR0';
+      doc.grpHdr.created = new Date();
+      doc.grpHdr.initiatorName = 'Example LLC';
+
+      var info = doc.createPaymentInfo();
+      info.requestedExecutionDate = new Date();
+      info.debtorIBAN = 'DE87123456781234567890';
+      info.debtorBIC = 'CUSTDEM0XXX';
+      info.debtorName = 'Example LLC';
+      setStructuredAddress(info, 'debtor');
+      doc.addPaymentInfo(info);
+
+      var tx = info.createTransaction();
+      tx.creditorName = 'Example Customer';
+      tx.creditorIBAN = 'DE40987654329876543210';
+      tx.creditorBIC = 'CUSTDEM0XXX';
+      tx.amount = 50.23;
+      tx.remittanceInfo = 'INVOICE 54';
+      tx.end2endId = 'XMPL.CUST487.INVOICE.54';
+      setHybridAddress(tx, 'creditor');
+      info.addTransaction(tx);
+
+      const validation = validateSchema(doc.toString(), fs.readFileSync('schema/' + format + '.xsd'));
+      expect(validation).toBe(true);
+    });
+
+    test.each([
+      'pain.008.001.02',
+      'pain.008.001.08',
+    ])('%p schema matches with structured and hybrid addresses', (format) => {
+      var doc = new SEPA.Document(format);
+      doc.grpHdr.id = 'XMPL.20140201.TR0';
+      doc.grpHdr.created = new Date();
+      doc.grpHdr.initiatorName = 'Example LLC';
+
+      var info = doc.createPaymentInfo();
+      info.collectionDate = new Date();
+      info.creditorIBAN = 'DE87123456781234567890';
+      info.creditorBIC = 'XMPLDEM0XXX';
+      info.creditorName = 'Example LLC';
+      info.creditorId = 'DE98ZZZ09999999999';
+      setStructuredAddress(info, 'creditor');
+      doc.addPaymentInfo(info);
+
+      var tx = info.createTransaction();
+      tx.debtorName = 'Example Customer';
+      tx.debtorIBAN = 'DE40987654329876543210';
+      tx.debtorBIC = 'CUSTDEM0XXX';
+      tx.mandateId = 'XMPL.CUST487.2014';
+      tx.mandateSignatureDate = new Date('2014-02-01');
+      tx.amount = 50.23;
+      tx.remittanceInfo = 'INVOICE 54';
+      tx.end2endId = 'XMPL.CUST487.INVOICE.54';
+      setHybridAddress(tx, 'debtor');
+      info.addTransaction(tx);
+
+      const validation = validateSchema(doc.toString(), fs.readFileSync('schema/' + format + '.xsd'));
+      expect(validation).toBe(true);
+    });
+
+    test('legacy street and city fields keep their historical output', () => {
+      var doc = new SEPA.Document('pain.001.001.03');
+      doc.grpHdr.id = 'XMPL.20140201.TR0';
+      doc.grpHdr.created = new Date();
+      doc.grpHdr.initiatorName = 'Example LLC';
+
+      var info = doc.createPaymentInfo();
+      info.requestedExecutionDate = new Date();
+      info.debtorIBAN = 'DE87123456781234567890';
+      info.debtorBIC = 'CUSTDEM0XXX';
+      info.debtorName = 'Example LLC';
+      info.debtorStreet = 'Musterstrasse 17';
+      info.debtorCity = 'Munich';
+      info.debtorCountry = 'DE';
+      doc.addPaymentInfo(info);
+
+      var tx = info.createTransaction();
+      tx.creditorName = 'Example Customer';
+      tx.creditorIBAN = 'DE40987654329876543210';
+      tx.creditorBIC = 'CUSTDEM0XXX';
+      tx.amount = 50.23;
+      tx.remittanceInfo = 'INVOICE 54';
+      tx.end2endId = 'XMPL.CUST487.INVOICE.54';
+      info.addTransaction(tx);
+
+      const xml = doc.toString();
+      expect(xml).toContain('<PstlAdr><Ctry>DE</Ctry><AdrLine>Musterstrasse 17</AdrLine><AdrLine>Munich</AdrLine></PstlAdr>');
+
+      const validation = validateSchema(xml, fs.readFileSync('schema/pain.001.001.03.xsd'));
+      expect(validation).toBe(true);
+    });
+  });

--- a/lib/sepa.js
+++ b/lib/sepa.js
@@ -422,6 +422,94 @@ function _addSingleChild(parent, childName, value = null) {
   return newNode;
 }
 
+/**
+ * Add a <PstlAdr> element for the given party, if any address data is set.
+ *
+ * Structured ISO 20022 elements (street name, building number, post code,
+ * town name, country sub division, address lines) take precedence and are
+ * emitted in the sequence order defined by the format's postal address type:
+ * PostalAddress6/PostalAddress24 place <AdrLine> last, while PostalAddress1
+ * (pain.001.001.02 only) places <AdrLine> before the structured elements.
+ * When only the legacy street/city fields are set, the historical output
+ * (country plus two unstructured address lines) is preserved for backward
+ * compatibility.
+ *
+ * @param parent {_SepaXmlNode}   The node receiving the <PstlAdr> child.
+ * @param source {object}         The payment info or transaction to read from.
+ * @param prefix {string}         Field prefix, either 'creditor' or 'debtor'.
+ * @private
+ */
+function _addPostalAddress(parent, source, prefix) {
+  const structuredElements = [
+    ['StrtNm', source[prefix + 'StreetName']],
+    ['BldgNb', source[prefix + 'BuildingNumber']],
+    ['PstCd', source[prefix + 'PostCode']],
+    ['TwnNm', source[prefix + 'TownName']],
+    ['CtrySubDvsn', source[prefix + 'CountrySubDivision']]
+  ];
+  const addressLines = source[prefix + 'AddressLines'] || [];
+  const hasStructuredData = structuredElements.some(([, value]) => value) || addressLines.length > 0;
+
+  if (hasStructuredData) {
+    const addressLinesFirst = source._painFormat === 'pain.001.001.02';
+    const pstlAdr = _addSingleChild(parent, 'PstlAdr');
+
+    if (addressLinesFirst) {
+      for (const line of addressLines) {
+        _addSingleChild(pstlAdr, 'AdrLine', line);
+      }
+    }
+    for (const [elementName, value] of structuredElements) {
+      if (value) {
+        _addSingleChild(pstlAdr, elementName, value);
+      }
+    }
+    if (source[prefix + 'Country']) {
+      _addSingleChild(pstlAdr, 'Ctry', source[prefix + 'Country']);
+    }
+    if (!addressLinesFirst) {
+      for (const line of addressLines) {
+        _addSingleChild(pstlAdr, 'AdrLine', line);
+      }
+    }
+  } else if (source[prefix + 'Street'] && source[prefix + 'City'] && source[prefix + 'Country']) {
+    const pstlAdr = _addSingleChild(parent, 'PstlAdr');
+    _addSingleChild(pstlAdr, 'Ctry', source[prefix + 'Country']);
+    _addSingleChild(pstlAdr, 'AdrLine', source[prefix + 'Street']);
+    _addSingleChild(pstlAdr, 'AdrLine', source[prefix + 'City']);
+  }
+}
+
+/**
+ * Validate the postal address fields for the given party.
+ *
+ * Lengths follow the PostalAddress6/PostalAddress24 schema definitions,
+ * which are identical across all supported pain formats.
+ *
+ * @param source {object}         The payment info or transaction to read from.
+ * @param prefix {string}         Field prefix, either 'creditor' or 'debtor'.
+ * @private
+ */
+function validate_postal_address(source, prefix) {
+  assert_length(source[prefix + 'Street'], null, 70, prefix + 'Street');
+  assert_length(source[prefix + 'City'], null, 70, prefix + 'City');
+  assert_length(source[prefix + 'Country'], null, 2, prefix + 'Country');
+  assert_length(source[prefix + 'StreetName'], null, 70, prefix + 'StreetName');
+  assert_length(source[prefix + 'BuildingNumber'], null, 16, prefix + 'BuildingNumber');
+  assert_length(source[prefix + 'PostCode'], null, 16, prefix + 'PostCode');
+  assert_length(source[prefix + 'TownName'], null, 35, prefix + 'TownName');
+  assert_length(source[prefix + 'CountrySubDivision'], null, 35, prefix + 'CountrySubDivision');
+
+  const addressLines = source[prefix + 'AddressLines'];
+  if (addressLines) {
+    assert(Array.isArray(addressLines), prefix + 'AddressLines must be an array');
+    assert_length(addressLines, null, 7, prefix + 'AddressLines');
+    for (const line of addressLines) {
+      assert_length(line, null, 70, prefix + 'AddressLines entry');
+    }
+  }
+}
+
 SepaGroupHeader.prototype = {
   _painFormat: null,
 
@@ -542,22 +630,44 @@ SepaPaymentInfo.prototype = {
 
   /** Name, Address, IBAN and BIC of the creditor */
   creditorName: '',
+  /** @deprecated Use creditorAddressLines and the structured creditor address fields instead. */
   creditorStreet: null,
+  /** @deprecated Use creditorTownName instead. */
   creditorCity: null,
   creditorCountry: null,
   creditorIBAN: '',
   creditorBIC: '',
+
+  /** Structured postal address of the creditor (ISO 20022 PostalAddress) */
+  creditorStreetName: null,
+  creditorBuildingNumber: null,
+  creditorPostCode: null,
+  creditorTownName: null,
+  creditorCountrySubDivision: null,
+  /** Unstructured address lines of the creditor, at most 7 entries of 70 characters */
+  creditorAddressLines: null,
 
   /** Id assigned to the debtor for Transfer payments */
   debtorId: '',
 
   /** Name, Address, IBAN and BIC of the debtor */
   debtorName: '',
+  /** @deprecated Use debtorAddressLines and the structured debtor address fields instead. */
   debtorStreet: null,
+  /** @deprecated Use debtorTownName instead. */
   debtorCity: null,
   debtorCountry: null,
   debtorIBAN: '',
   debtorBIC: '',
+
+  /** Structured postal address of the debtor (ISO 20022 PostalAddress) */
+  debtorStreetName: null,
+  debtorBuildingNumber: null,
+  debtorPostCode: null,
+  debtorTownName: null,
+  debtorCountrySubDivision: null,
+  /** Unstructured address lines of the debtor, at most 7 entries of 70 characters */
+  debtorAddressLines: null,
 
   /** SEPA order priority, can be HIGH or NORM */
   instructionPriority: 'NORM',
@@ -632,9 +742,7 @@ SepaPaymentInfo.prototype = {
     }
 
     assert_length(this[pullFrom + 'Name'], null, 70, pullFrom + 'Name');
-    assert_length(this[pullFrom + 'Street'], null, 70, pullFrom + 'Street');
-    assert_length(this[pullFrom + 'City'], null, 70, pullFrom + 'City');
-    assert_length(this[pullFrom + 'Country'], null, 2, pullFrom + 'Country');
+    validate_postal_address(this, pullFrom);
     assert_iban(this[pullFrom + 'IBAN'], pullFrom + 'IBAN');
     assert_length(this[pullFrom + 'BIC'], [0,8,11], pullFrom + 'BIC');
     var countryMatches = (this[pullFrom + 'BIC'].length === 0 || this[pullFrom + 'BIC'].substr(4, 2) === this[pullFrom + 'IBAN'].substr(0, 2));
@@ -696,12 +804,7 @@ SepaPaymentInfo.prototype = {
 
     _addSingleChild(emitter, 'Nm', this[pullFrom + 'Name']);
 
-    if (this[pullFrom + 'Street'] && this[pullFrom + 'City'] && this[pullFrom + 'Country']) {
-      const pstl = _addSingleChild(emitter, 'PstlAdr');
-      _addSingleChild(pstl,'Ctry', this[pullFrom + 'Country']);
-      _addSingleChild(pstl,'AdrLine', this[pullFrom + 'Street']);
-      _addSingleChild(pstl,'AdrLine', this[pullFrom + 'City']);
-    }
+    _addPostalAddress(emitter, this, pullFrom);
 
     _addNestedChildren(pmtInf, [emitterNodeName + 'Acct', 'Id', 'IBAN'], this[pullFrom + 'IBAN']);
 
@@ -779,11 +882,22 @@ SepaTransaction.prototype = {
 
   /** Name, Address, IBAN and BIC of the debtor */
   debtorName: '',
+  /** @deprecated Use debtorAddressLines and the structured debtor address fields instead. */
   debtorStreet: null,
+  /** @deprecated Use debtorTownName instead. */
   debtorCity: null,
   debtorCountry: null,
   debtorIBAN: '',
   debtorBIC: '',
+
+  /** Structured postal address of the debtor (ISO 20022 PostalAddress) */
+  debtorStreetName: null,
+  debtorBuildingNumber: null,
+  debtorPostCode: null,
+  debtorTownName: null,
+  debtorCountrySubDivision: null,
+  /** Unstructured address lines of the debtor, at most 7 entries of 70 characters */
+  debtorAddressLines: null,
 
   /** Unstructured Remittance Info */
   remittanceInfo: '',
@@ -800,11 +914,22 @@ SepaTransaction.prototype = {
 
   /** Name, Address, IBAN and BIC of the creditor */
   creditorName: '',
+  /** @deprecated Use creditorAddressLines and the structured creditor address fields instead. */
   creditorStreet: null,
+  /** @deprecated Use creditorTownName instead. */
   creditorCity: null,
   creditorCountry: null,
   creditorIBAN: '',
   creditorBIC: '',
+
+  /** Structured postal address of the creditor (ISO 20022 PostalAddress) */
+  creditorStreetName: null,
+  creditorBuildingNumber: null,
+  creditorPostCode: null,
+  creditorTownName: null,
+  creditorCountrySubDivision: null,
+  /** Unstructured address lines of the creditor, at most 7 entries of 70 characters */
+  creditorAddressLines: null,
 
   validate: function() {
     var pullFrom = this._type === TransactionTypes.Transfer ? 'creditor' : 'debtor';
@@ -820,9 +945,7 @@ SepaTransaction.prototype = {
     }
 
     assert_length(this[pullFrom + 'Name'], null, 70, pullFrom + 'Name');
-    assert_length(this[pullFrom + 'Street'], null, 70, pullFrom + 'Street');
-    assert_length(this[pullFrom + 'City'], null, 70, pullFrom + 'City');
-    assert_length(this[pullFrom + 'Country'], null, 2, pullFrom + 'Country');
+    validate_postal_address(this, pullFrom);
     assert_iban(this[pullFrom + 'IBAN'], pullFrom + 'IBAN');
     assert_fixed(this[pullFrom + 'BIC'].length, [0, 8, 11], pullFrom + 'BIC');
     var countryMatches = (this[pullFrom + 'BIC'].length === 0 || this[pullFrom + 'BIC'].substr(4, 2) === this[pullFrom + 'IBAN'].substr(0, 2));
@@ -914,12 +1037,7 @@ SepaTransaction.prototype = {
     const receiver = _addSingleChild(txInf, receiverNodeName);
     _addSingleChild(receiver, 'Nm', this[pullFrom + 'Name']);
 
-    if (this[pullFrom + 'Street'] && this[pullFrom + 'City'] && this[pullFrom + 'Country']) {
-      const pstlAdr = _addSingleChild(receiver, 'PstlAdr');
-      _addSingleChild(pstlAdr, 'Ctry', this[pullFrom + 'Country']);
-      _addSingleChild(pstlAdr, 'AdrLine', this[pullFrom + 'Street']);
-      _addSingleChild(pstlAdr, 'AdrLine', this[pullFrom + 'City']);
-    }
+    _addPostalAddress(receiver, this, pullFrom);
 
     _addNestedChildren(txInf, [receiverNodeName + 'Acct', 'Id', 'IBAN'], this[pullFrom + 'IBAN']);
 

--- a/lib/sepa.js
+++ b/lib/sepa.js
@@ -483,8 +483,9 @@ function _addPostalAddress(parent, source, prefix) {
 /**
  * Validate the postal address fields for the given party.
  *
- * Lengths follow the PostalAddress6/PostalAddress24 schema definitions,
- * which are identical across all supported pain formats.
+ * Element lengths are identical across all supported pain formats; the only
+ * format difference is the number of address lines, which PostalAddress1
+ * (pain.001.001.02) caps at 5 instead of 7.
  *
  * @param source {object}         The payment info or transaction to read from.
  * @param prefix {string}         Field prefix, either 'creditor' or 'debtor'.
@@ -502,8 +503,10 @@ function validate_postal_address(source, prefix) {
 
   const addressLines = source[prefix + 'AddressLines'];
   if (addressLines) {
+    const maxAddressLines = source._painFormat === 'pain.001.001.02' ? 5 : 7;
     assert(Array.isArray(addressLines), prefix + 'AddressLines must be an array');
-    assert_length(addressLines, null, 7, prefix + 'AddressLines');
+    assert(addressLines.length <= maxAddressLines,
+      prefix + 'AddressLines supports at most ' + maxAddressLines + ' entries for ' + source._painFormat);
     for (const line of addressLines) {
       assert_length(line, null, 70, prefix + 'AddressLines entry');
     }
@@ -644,7 +647,7 @@ SepaPaymentInfo.prototype = {
   creditorPostCode: null,
   creditorTownName: null,
   creditorCountrySubDivision: null,
-  /** Unstructured address lines of the creditor, at most 7 entries of 70 characters */
+  /** Unstructured address lines of the creditor, at most 7 entries of 70 characters (5 for pain.001.001.02) */
   creditorAddressLines: null,
 
   /** Id assigned to the debtor for Transfer payments */
@@ -666,7 +669,7 @@ SepaPaymentInfo.prototype = {
   debtorPostCode: null,
   debtorTownName: null,
   debtorCountrySubDivision: null,
-  /** Unstructured address lines of the debtor, at most 7 entries of 70 characters */
+  /** Unstructured address lines of the debtor, at most 7 entries of 70 characters (5 for pain.001.001.02) */
   debtorAddressLines: null,
 
   /** SEPA order priority, can be HIGH or NORM */
@@ -896,7 +899,7 @@ SepaTransaction.prototype = {
   debtorPostCode: null,
   debtorTownName: null,
   debtorCountrySubDivision: null,
-  /** Unstructured address lines of the debtor, at most 7 entries of 70 characters */
+  /** Unstructured address lines of the debtor, at most 7 entries of 70 characters (5 for pain.001.001.02) */
   debtorAddressLines: null,
 
   /** Unstructured Remittance Info */
@@ -928,7 +931,7 @@ SepaTransaction.prototype = {
   creditorPostCode: null,
   creditorTownName: null,
   creditorCountrySubDivision: null,
-  /** Unstructured address lines of the creditor, at most 7 entries of 70 characters */
+  /** Unstructured address lines of the creditor, at most 7 entries of 70 characters (5 for pain.001.001.02) */
   creditorAddressLines: null,
 
   validate: function() {

--- a/lib/sepa.test.js
+++ b/lib/sepa.test.js
@@ -1246,4 +1246,20 @@ describe('structured postal address tests', () => {
     // WHEN THEN
     expect(() => doc.toString()).toThrow(Error);
   });
+
+  test('caps address lines at 5 for pain.001.001.02 and 7 for the other formats', () => {
+    // GIVEN six address lines, above the PostalAddress1 limit but within the
+    // PostalAddress6/PostalAddress24 one
+    const sixLines = ['1', '2', '3', '4', '5', '6'];
+
+    const oldFormatDoc = validTransferDocument({painFormat: 'pain.001.001.02'});
+    oldFormatDoc._paymentInfo[0]._payments[0].creditorAddressLines = sixLines;
+
+    const recentFormatDoc = validTransferDocument({});
+    recentFormatDoc._paymentInfo[0]._payments[0].creditorAddressLines = sixLines;
+
+    // WHEN THEN
+    expect(() => oldFormatDoc.toString()).toThrow(/at most 5 entries/);
+    expect(() => recentFormatDoc.toString()).not.toThrow();
+  });
 });

--- a/lib/sepa.test.js
+++ b/lib/sepa.test.js
@@ -1113,3 +1113,137 @@ describe('XML tests', () => {
     expect(xmlString).toBe(expectedOutput);
   });
 });
+
+describe('structured postal address tests', () => {
+  const NS = {p: `urn:iso:std:iso:20022:tech:xsd:${PAIN_FOR_TRANSFERS}`};
+
+  function parse(doc) {
+    return new xmldom.DOMParser().parseFromString(doc.toString(), 'text/xml');
+  }
+
+  function childNames(node) {
+    return Array.from(node.childNodes)
+      .filter((child) => child.nodeType === 1)
+      .map((child) => child.nodeName);
+  }
+
+  test('emits structured elements in schema order for payment info and transaction', () => {
+    // GIVEN
+    const doc = validTransferDocument({});
+    const info = doc._paymentInfo[0];
+    info.debtorStreetName = 'Musterstrasse';
+    info.debtorBuildingNumber = '17';
+    info.debtorPostCode = '80331';
+    info.debtorTownName = 'Munich';
+    info.debtorCountrySubDivision = 'BY';
+    info.debtorCountry = 'DE';
+
+    const tx = info._payments[0];
+    tx.creditorStreetName = 'Rue de la Paix';
+    tx.creditorBuildingNumber = '42bis';
+    tx.creditorPostCode = '75002';
+    tx.creditorTownName = 'Paris';
+    tx.creditorCountry = 'FR';
+
+    // WHEN
+    const dom = parse(doc);
+
+    // THEN
+    const select = xpath.useNamespaces(NS);
+    const debtorAddress = select('/p:Document/p:CstmrCdtTrfInitn/p:PmtInf/p:Dbtr/p:PstlAdr', dom, true);
+    expect(childNames(debtorAddress)).toEqual(['StrtNm', 'BldgNb', 'PstCd', 'TwnNm', 'CtrySubDvsn', 'Ctry']);
+    expect(select('p:TwnNm', debtorAddress, true).textContent).toBe('Munich');
+
+    const creditorAddress = select('/p:Document/p:CstmrCdtTrfInitn/p:PmtInf/p:CdtTrfTxInf[1]/p:Cdtr/p:PstlAdr', dom, true);
+    expect(childNames(creditorAddress)).toEqual(['StrtNm', 'BldgNb', 'PstCd', 'TwnNm', 'Ctry']);
+    expect(select('p:BldgNb', creditorAddress, true).textContent).toBe('42bis');
+  });
+
+  test('emits a hybrid address with structured locality and unstructured address lines', () => {
+    // GIVEN
+    const doc = validTransferDocument({});
+    const tx = doc._paymentInfo[0]._payments[0];
+    tx.creditorPostCode = '75002';
+    tx.creditorTownName = 'Paris';
+    tx.creditorCountry = 'FR';
+    tx.creditorAddressLines = ['123 Rue de la Paix', 'Batiment B'];
+
+    // WHEN
+    const dom = parse(doc);
+
+    // THEN
+    const select = xpath.useNamespaces(NS);
+    const address = select('/p:Document/p:CstmrCdtTrfInitn/p:PmtInf/p:CdtTrfTxInf[1]/p:Cdtr/p:PstlAdr', dom, true);
+    expect(childNames(address)).toEqual(['PstCd', 'TwnNm', 'Ctry', 'AdrLine', 'AdrLine']);
+    expect(select('p:AdrLine[1]', address, true).textContent).toBe('123 Rue de la Paix');
+    expect(select('p:AdrLine[2]', address, true).textContent).toBe('Batiment B');
+  });
+
+  test('places address lines before structured elements for pain.001.001.02', () => {
+    // GIVEN
+    const doc = validTransferDocument({painFormat: 'pain.001.001.02'});
+    const tx = doc._paymentInfo[0]._payments[0];
+    tx.creditorTownName = 'Paris';
+    tx.creditorCountry = 'FR';
+    tx.creditorAddressLines = ['123 Rue de la Paix'];
+
+    // WHEN
+    const dom = parse(doc);
+
+    // THEN
+    const select = xpath.useNamespaces({p: 'urn:iso:std:iso:20022:tech:xsd:pain.001.001.02'});
+    const address = select('//p:Cdtr/p:PstlAdr', dom, true);
+    expect(childNames(address)).toEqual(['AdrLine', 'TwnNm', 'Ctry']);
+  });
+
+  test('structured fields take precedence over the deprecated street and city fields', () => {
+    // GIVEN
+    const doc = validTransferDocument({
+      creditorCountry: 'FR',
+      creditorStreet: 'legacy street',
+      creditorCity: 'legacy city'});
+    const tx = doc._paymentInfo[0]._payments[0];
+    tx.creditorTownName = 'Paris';
+
+    // WHEN
+    const dom = parse(doc);
+
+    // THEN
+    const select = xpath.useNamespaces(NS);
+    const address = select('/p:Document/p:CstmrCdtTrfInitn/p:PmtInf/p:CdtTrfTxInf[1]/p:Cdtr/p:PstlAdr', dom, true);
+    expect(childNames(address)).toEqual(['TwnNm', 'Ctry']);
+  });
+
+  test('emits the debtor structured address on direct debit transactions', () => {
+    // GIVEN
+    const doc = validDirectDebitDocument({});
+    const tx = doc._paymentInfo[0]._payments[0];
+    tx.debtorName = 'debtor-name';
+    tx.debtorPostCode = 'EC1A 1BB';
+    tx.debtorTownName = 'London';
+    tx.debtorCountry = 'GB';
+    tx.debtorAddressLines = ['160 Aldersgate Street'];
+
+    // WHEN
+    const dom = parse(doc);
+
+    // THEN
+    const select = xpath.useNamespaces({p: `urn:iso:std:iso:20022:tech:xsd:${PAIN_FOR_DIRECT_DEBIT}`});
+    const address = select('//p:DrctDbtTxInf/p:Dbtr/p:PstlAdr', dom, true);
+    expect(childNames(address)).toEqual(['PstCd', 'TwnNm', 'Ctry', 'AdrLine']);
+  });
+
+  test.each([
+    ['creditorBuildingNumber', 'this building number is way over sixteen characters'],
+    ['creditorPostCode', 'this post code is way over sixteen characters'],
+    ['creditorTownName', 'this town name is longer than the thirty five characters allowed'],
+    ['creditorAddressLines', ['1', '2', '3', '4', '5', '6', '7', '8']],
+  ])('rejects invalid %s', (field, value) => {
+    // GIVEN
+    const doc = validTransferDocument({});
+    doc._paymentInfo[0]._payments[0][field] = value;
+
+    // WHEN THEN
+    expect(() => doc.toString()).toThrow(Error);
+  });
+});

--- a/types/sepa.d.ts
+++ b/types/sepa.d.ts
@@ -101,9 +101,9 @@ declare module "sepa" {
 
     /** Name of the debtor */
     debtorName: string;
-    /** Street of the debtor */
+    /** @deprecated Use debtorAddressLines and the structured debtor address fields instead. */
     debtorStreet: string | null;
-    /** City of the debtor */
+    /** @deprecated Use debtorTownName instead. */
     debtorCity: string | null;
     /** Country of the debtor */
     debtorCountry: string | null;
@@ -111,6 +111,19 @@ declare module "sepa" {
     debtorIBAN: string;
     /** BIC of the debtor */
     debtorBIC: string;
+
+    /** Street name of the debtor (<StrtNm>) */
+    debtorStreetName: string | null;
+    /** Building number of the debtor (<BldgNb>) */
+    debtorBuildingNumber: string | null;
+    /** Post code of the debtor (<PstCd>) */
+    debtorPostCode: string | null;
+    /** Town name of the debtor (<TwnNm>) */
+    debtorTownName: string | null;
+    /** Country sub division of the debtor (<CtrySubDvsn>) */
+    debtorCountrySubDivision: string | null;
+    /** Unstructured address lines of the debtor (<AdrLine>), at most 7 entries of 70 characters */
+    debtorAddressLines: string[] | null;
 
     /** Unstructured Remittance Info */
     remittanceInfo: string;
@@ -126,9 +139,9 @@ declare module "sepa" {
 
     /** Name of the creditor */
     creditorName: string;
-    /** Street of the creditor */
+    /** @deprecated Use creditorAddressLines and the structured creditor address fields instead. */
     creditorStreet: string | null;
-    /** City of the creditor */
+    /** @deprecated Use creditorTownName instead. */
     creditorCity: string | null;
     /** Country of the creditor */
     creditorCountry: string | null;
@@ -136,6 +149,19 @@ declare module "sepa" {
     creditorIBAN: string;
     /** BIC of the creditor */
     creditorBIC: string;
+
+    /** Street name of the creditor (<StrtNm>) */
+    creditorStreetName: string | null;
+    /** Building number of the creditor (<BldgNb>) */
+    creditorBuildingNumber: string | null;
+    /** Post code of the creditor (<PstCd>) */
+    creditorPostCode: string | null;
+    /** Town name of the creditor (<TwnNm>) */
+    creditorTownName: string | null;
+    /** Country sub division of the creditor (<CtrySubDvsn>) */
+    creditorCountrySubDivision: string | null;
+    /** Unstructured address lines of the creditor (<AdrLine>), at most 7 entries of 70 characters */
+    creditorAddressLines: string[] | null;
 
     constructor(painFormat: string);
     validate(): void;
@@ -187,9 +213,9 @@ declare module "sepa" {
     originalCreditorId: string | null;
     /** Name of the creditor */
     creditorName: string;
-    /** Street of the creditor */
+    /** @deprecated Use creditorAddressLines and the structured creditor address fields instead. */
     creditorStreet: string | null;
-    /** City of the creditor */
+    /** @deprecated Use creditorTownName instead. */
     creditorCity: string | null;
     /** Country of the creditor */
     creditorCountry: string | null;
@@ -198,13 +224,26 @@ declare module "sepa" {
     /** BIC of the creditor */
     creditorBIC: string;
 
+    /** Street name of the creditor (<StrtNm>) */
+    creditorStreetName: string | null;
+    /** Building number of the creditor (<BldgNb>) */
+    creditorBuildingNumber: string | null;
+    /** Post code of the creditor (<PstCd>) */
+    creditorPostCode: string | null;
+    /** Town name of the creditor (<TwnNm>) */
+    creditorTownName: string | null;
+    /** Country sub division of the creditor (<CtrySubDvsn>) */
+    creditorCountrySubDivision: string | null;
+    /** Unstructured address lines of the creditor (<AdrLine>), at most 7 entries of 70 characters */
+    creditorAddressLines: string[] | null;
+
     /** Id assigned to the debtor for Transfer payments */
     debtorId: string;
     /** Name of the debtor */
     debtorName: string;
-    /** Street of the debtor */
+    /** @deprecated Use debtorAddressLines and the structured debtor address fields instead. */
     debtorStreet: string | null;
-    /** City of the debtor */
+    /** @deprecated Use debtorTownName instead. */
     debtorCity: string | null;
     /** Country of the debtor */
     debtorCountry: string | null;
@@ -212,6 +251,19 @@ declare module "sepa" {
     debtorIBAN: string;
     /** BIC of the debtor */
     debtorBIC: string;
+
+    /** Street name of the debtor (<StrtNm>) */
+    debtorStreetName: string | null;
+    /** Building number of the debtor (<BldgNb>) */
+    debtorBuildingNumber: string | null;
+    /** Post code of the debtor (<PstCd>) */
+    debtorPostCode: string | null;
+    /** Town name of the debtor (<TwnNm>) */
+    debtorTownName: string | null;
+    /** Country sub division of the debtor (<CtrySubDvsn>) */
+    debtorCountrySubDivision: string | null;
+    /** Unstructured address lines of the debtor (<AdrLine>), at most 7 entries of 70 characters */
+    debtorAddressLines: string[] | null;
 
     /** SEPA order priority */
     instructionPriority: "HIGH" | "NORM";

--- a/types/sepa.d.ts
+++ b/types/sepa.d.ts
@@ -122,7 +122,7 @@ declare module "sepa" {
     debtorTownName: string | null;
     /** Country sub division of the debtor (<CtrySubDvsn>) */
     debtorCountrySubDivision: string | null;
-    /** Unstructured address lines of the debtor (<AdrLine>), at most 7 entries of 70 characters */
+    /** Unstructured address lines of the debtor (<AdrLine>), at most 7 entries of 70 characters (5 for pain.001.001.02) */
     debtorAddressLines: string[] | null;
 
     /** Unstructured Remittance Info */
@@ -160,7 +160,7 @@ declare module "sepa" {
     creditorTownName: string | null;
     /** Country sub division of the creditor (<CtrySubDvsn>) */
     creditorCountrySubDivision: string | null;
-    /** Unstructured address lines of the creditor (<AdrLine>), at most 7 entries of 70 characters */
+    /** Unstructured address lines of the creditor (<AdrLine>), at most 7 entries of 70 characters (5 for pain.001.001.02) */
     creditorAddressLines: string[] | null;
 
     constructor(painFormat: string);
@@ -234,7 +234,7 @@ declare module "sepa" {
     creditorTownName: string | null;
     /** Country sub division of the creditor (<CtrySubDvsn>) */
     creditorCountrySubDivision: string | null;
-    /** Unstructured address lines of the creditor (<AdrLine>), at most 7 entries of 70 characters */
+    /** Unstructured address lines of the creditor (<AdrLine>), at most 7 entries of 70 characters (5 for pain.001.001.02) */
     creditorAddressLines: string[] | null;
 
     /** Id assigned to the debtor for Transfer payments */
@@ -262,7 +262,7 @@ declare module "sepa" {
     debtorTownName: string | null;
     /** Country sub division of the debtor (<CtrySubDvsn>) */
     debtorCountrySubDivision: string | null;
-    /** Unstructured address lines of the debtor (<AdrLine>), at most 7 entries of 70 characters */
+    /** Unstructured address lines of the debtor (<AdrLine>), at most 7 entries of 70 characters (5 for pain.001.001.02) */
     debtorAddressLines: string[] | null;
 
     /** SEPA order priority */


### PR DESCRIPTION
Closes #255.

From **November 2026**, EPC and Swift decommission fully unstructured postal addresses in SEPA and cross-border payments: a `<PstlAdr>` carrying only `<AdrLine>` elements — or missing `<TwnNm>`/`<Ctry>` — will be rejected by banks. The current `street`/`city` fields serialize exactly that shape (`<Ctry>` plus two `<AdrLine>`), so every sepa.js user emitting addresses is affected.

This PR adds the structured PostalAddress elements shared by every supported pain format — `<StrtNm>`, `<BldgNb>`, `<PstCd>`, `<TwnNm>`, `<CtrySubDvsn>`, `<Ctry>`, `<AdrLine>` — on both PaymentInfo (Dbtr/Cdtr) and Transaction (Cdtr/Dbtr) parties, emitted in the schema sequence order. It also adds the elements only defined by `PostalAddress24`, used by the 2019 formats `pain.001.001.09` and `pain.008.001.08`: `<Dept>`, `<SubDept>`, `<BldgNm>`, `<Flr>`, `<PstBx>`, `<Room>`, `<TwnLctnNm>`, `<DstrctNm>`. Both compliant profiles become expressible: **fully structured**, and **hybrid** (structured locality + up to 2 unstructured address lines, the profile recommended by most banks and treasury platforms).

Design notes:
- Format support is enforced: setting a `PostalAddress24`-only element on an older format throws (`Dept`/`SubDept` are only rejected by `pain.001.001.02`, whose `PostalAddress1` lacks them). `<AdrTp>` is deliberately left out, as the EPC structured address guidance excludes it.
- `pain.001.001.02` (`PostalAddress1`) places `<AdrLine>` before the structured elements and its ordering is honored; all other formats (`PostalAddress6`/`PostalAddress24`) share the same sequence.
- Validations follow the schema lengths (`StrtNm` 70, `BldgNb` 16, `PstCd` 16, `TwnNm` 35, `CtrySubDvsn` 35, `Dept`/`SubDept`/`Flr`/`Room` 70, `BldgNm`/`TwnLctnNm`/`DstrctNm` 35, `PstBx` 16, `AdrLine` 70×7, capped at 5 for pain.001.001.02 (PostalAddress1)), wired into the existing `enableValidations` switch.
- **No behavior change for existing users**: the legacy `street`/`city` fields are deprecated but keep their historical output byte-for-byte (locked by a test); structured fields take precedence when both are set.
- Schema validation tests cover structured + hybrid addresses against all six embedded XSDs, plus every `PostalAddress24` element against the pain.001.001.09 and pain.008.001.08 XSDs.

Follow-up to #203 (mandate amendments) — same approach: a need we hit in production, contributed in ISO terms.
